### PR TITLE
Fix for Apple Sillicon: Added conditional Homebrew prefix path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+xcuserdata/
+xcshareddata/

--- a/Redis/Redis.h
+++ b/Redis/Redis.h
@@ -22,6 +22,7 @@
     NSString *_redis_server;
     NSString *_redis_conf;
     NSString *_launchctl;
+    NSString *_brew_prefix;
     NSTextField *__strong _startedSubtext;
     NSImageView *__strong _statusImage;
     
@@ -38,6 +39,7 @@
 @property (nonatomic, strong) NSString *redis_cli;
 @property (nonatomic, strong) NSString *redis_server;
 @property (nonatomic, strong) NSString *redis_conf;
+@property (nonatomic, strong) NSString *brew_prefix;
 @property (nonatomic, strong) NSString *launchctl;
 @property (strong) IBOutlet NSTextField *startedSubtext;
 @property (strong) IBOutlet NSImageView *statusImage;

--- a/Redis/Redis.m
+++ b/Redis/Redis.m
@@ -26,6 +26,7 @@
 @synthesize redis_cli = _redis_cli;
 @synthesize redis_server = _redis_server;
 @synthesize redis_conf = _redis_conf;
+@synthesize brew_prefix = _brew_prefix;
 @synthesize launchctl = _launchctl;
 @synthesize startedSubtext = _startedSubtext;
 @synthesize statusImage = _statusImage;
@@ -125,21 +126,28 @@
 
 - (void)startup {
     NSArray *args = nil;
+
+    NSFileManager *fm = [[NSFileManager alloc] init];
+    BOOL isDir;
+    if ([fm fileExistsAtPath:@"/opt/homebrew" isDirectory:&isDir] ) {
+        self.brew_prefix = @"/opt/homebrew";
+    } else {
+        self.brew_prefix = @"/usr/local";
+    }
     
     args = [NSArray arrayWithObjects: LAUNCHCTL, nil];
     self.launchctl = [self runCLICommand:WHICH arguments:args];
     self.launchctl = [self.launchctl stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
   
-    args = [NSArray arrayWithObjects:@"/usr/local/Cellar",@"-type", @"f", @"-name", REDIS_CLI, nil];
+    args = [NSArray arrayWithObjects:[NSString stringWithFormat:@"%@/Cellar", self.brew_prefix],@"-type", @"f", @"-name", REDIS_CLI, nil];
     self.redis_cli = [self runCLICommand:FIND arguments:args];
     self.redis_cli = [self.redis_cli stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
   
-  
-    args = [NSArray arrayWithObjects:@"/usr/local/Cellar",@"-type", @"f", @"-name", REDIS_SERVER, nil];
+    args = [NSArray arrayWithObjects:[NSString stringWithFormat:@"%@/Cellar", self.brew_prefix] ,@"-type", @"f", @"-name", REDIS_SERVER, nil];
     self.redis_server = [self runCLICommand:FIND arguments:args];
     self.redis_server = [self.redis_server stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
   
-    args = [NSArray arrayWithObjects:@"/usr/local/etc",@"-type", @"f", @"-name", @"redis.conf", nil];
+    args = [NSArray arrayWithObjects:[NSString stringWithFormat:@"%@/etc", self.brew_prefix],@"-type", @"f", @"-name", @"redis.conf", nil];
     self.redis_conf = [self runCLICommand:FIND arguments:args];
     self.redis_conf = [self.redis_conf stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
   

--- a/Redis/en.lproj/Redis.xib
+++ b/Redis/en.lproj/Redis.xib
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9059" systemVersion="15B42" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="18122" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
-        <deployment version="1050" identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9059"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="18122"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="Postgres">
@@ -19,20 +19,19 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="&lt;&lt; do not localize &gt;&gt;" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" deferred="NO" oneShot="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="12" userLabel="PrefPane">
+        <window title="&lt;&lt; do not localize &gt;&gt;" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" deferred="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="12" userLabel="PrefPane">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="176" y="715" width="668" height="277"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1028"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="875"/>
             <value key="minSize" type="size" width="224.66399999999999" height="10"/>
             <view key="contentView" id="6">
                 <rect key="frame" x="0.0" y="0.0" width="668" height="277"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <button verticalHuggingPriority="750" id="101">
+                    <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="101">
                         <rect key="frame" x="393" y="162" width="181" height="32"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <animations/>
                         <buttonCell key="cell" type="push" title="Start Redis Server" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="102">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -41,10 +40,9 @@
                             <action selector="startStopServer:" target="-2" id="127"/>
                         </connections>
                     </button>
-                    <button id="103">
+                    <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="103">
                         <rect key="frame" x="81" y="81" width="293" height="18"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <animations/>
                         <buttonCell key="cell" type="check" title="Automatically Start Redis Server on Startup" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="104">
                             <behavior key="behavior" pushIn="YES" changeContents="YES" lightByContents="YES"/>
                             <font key="font" metaFont="system"/>
@@ -53,94 +51,81 @@
                             <action selector="autoStartChanged:" target="-2" id="129"/>
                         </connections>
                     </button>
-                    <textField verticalHuggingPriority="750" id="107">
+                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="107">
                         <rect key="frame" x="80" y="36" width="321" height="39"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <animations/>
                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="You may select to have the Redis server start automatically whenever your computer starts up." id="108">
                             <font key="font" metaFont="smallSystem"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <textField hidden="YES" verticalHuggingPriority="750" id="119">
+                    <textField hidden="YES" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="119">
                         <rect key="frame" x="80" y="128" width="352" height="37"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <animations/>
                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="If you stop the server, you and your applications will not be able to use Redis and all current connections will be closed." id="120">
                             <font key="font" metaFont="smallSystem"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <textField verticalHuggingPriority="750" id="109">
+                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="109">
                         <rect key="frame" x="80" y="198" width="528" height="34"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <animations/>
                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="The Redis Database Server is currently stopped. To start it, use the &quot;Start Redis Server&quot; button." id="110">
                             <font key="font" metaFont="smallSystem"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <textField verticalHuggingPriority="750" id="111">
+                    <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="111">
                         <rect key="frame" x="80" y="240" width="124" height="17"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <animations/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Redis Server Status" id="112">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <textField verticalHuggingPriority="750" id="113">
+                    <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="113">
                         <rect key="frame" x="80" y="173" width="180" height="17"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <animations/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="The Redis Server Instance is" id="114">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <textField verticalHuggingPriority="750" id="117">
+                    <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="117">
                         <rect key="frame" x="281" y="173" width="100" height="17"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <animations/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="..." id="118">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" red="1" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <box verticalHuggingPriority="750" title="Box" boxType="separator" titlePosition="noTitle" id="123">
+                    <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="123">
                         <rect key="frame" x="43" y="119" width="583" height="5"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <animations/>
-                        <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
-                        <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                        <font key="titleFont" metaFont="system"/>
                     </box>
-                    <imageView id="143">
+                    <imageView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="143">
                         <rect key="frame" x="17" y="191" width="48" height="48"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <animations/>
                         <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="stopped" id="144"/>
                     </imageView>
-                    <progressIndicator horizontalHuggingPriority="750" verticalHuggingPriority="750" maxValue="100" displayedWhenStopped="NO" bezeled="NO" indeterminate="YES" controlSize="small" style="spinning" id="145">
+                    <progressIndicator horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" maxValue="100" displayedWhenStopped="NO" bezeled="NO" indeterminate="YES" controlSize="small" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="145">
                         <rect key="frame" x="367" y="172" width="16" height="16"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <animations/>
                     </progressIndicator>
-                    <imageView id="147">
+                    <imageView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="147">
                         <rect key="frame" x="435" y="20" width="191" height="93"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <animations/>
                         <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="logo" id="148"/>
                     </imageView>
                 </subviews>
-                <animations/>
             </view>
+            <point key="canvasLocation" x="21" y="140"/>
         </window>
     </objects>
     <resources>


### PR DESCRIPTION
On Apple Sillicon, Homebrew is installed in `/opt/homebrew` instead of `/usr/local`.
To make Redis.prefPane work on Apple Sillicon, I added a conditional homebrew prefix.

I nice way of getting the prefix normally, is executing `brew --prefix`. But this does not work with `NSTask`, because you don't know the location of `brew`, and `which brew` does not work either with `NSTask`.

Therefore I settled on just checking the existence of the  `/opt/homebrew` directory.